### PR TITLE
Fix memory initialization

### DIFF
--- a/src/packages/web-worker/pvm.ts
+++ b/src/packages/web-worker/pvm.ts
@@ -21,7 +21,7 @@ export const initPvm = (pvm: InternalPvmInstance, program: Uint8Array, initialSt
   }
 
   for (const memoryChunk of initialMemory) {
-    memoryBuilder.setData(memoryChunk.address, memoryChunk.contents);
+    memoryBuilder.setData(memoryChunk.address, new Uint8Array(memoryChunk.contents));
   }
 
   //const HEAP_START_PAGE = 4 * 2 ** 16;

--- a/src/types/pvm.ts
+++ b/src/types/pvm.ts
@@ -15,7 +15,7 @@ export type InitialState = {
 
 export type MemoryChunkItem = {
   address: number;
-  contents: Uint8Array;
+  contents: number[];
 };
 
 export type PageMapItem = {


### PR DESCRIPTION
Because of incorrect type definition we pass `number[]` instead of `Uint8Array` to `setData`. I fixed incorrect type and converted the object to `Uint8Array`