### PR TITLE
64-bit migration prep: load 32-bit version of ananas 

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -8,6 +8,9 @@ export const Header = () => {
       <div className="flex items-center gap-5">
         <img src={Logo} alt="FluffyLabs logo" className="w-[90px] ml-3" />
         <pre className="text-brand">PVM debugger</pre>
+        <pre className="text-white text-xs">
+          <a href="https://pvm-debugger.netlify.app/">64-bit beta</a>
+        </pre>
       </div>
       <div className="mr-3 text-white flex flex-row items-center justify-center gap-5">
         <TooltipProvider>

--- a/src/components/PvmSelect/index.tsx
+++ b/src/components/PvmSelect/index.tsx
@@ -35,6 +35,7 @@ interface WasmMetadata {
     resetPolkaVM: boolean;
   };
   wasmBlobUrl: string;
+  wasmBlobUrl32?: string;
 }
 
 export interface SelectedPvmWithPayload {
@@ -170,7 +171,7 @@ export const PvmSelect = () => {
             id: value,
             type: PvmTypes.WASM_URL,
             params: {
-              url: path.join(url, "../", metadata.wasmBlobUrl),
+              url: path.join(url, "../", metadata.wasmBlobUrl32 || metadata.wasmBlobUrl),
               lang,
             },
           },


### PR DESCRIPTION
This can be deployed to prod, while we have 64-bit on beta.

Related: #244 
Related: #254 