### PR TITLE
Fix memory initialization

### DIFF
--- a/src/packages/web-worker/pvm.ts
+++ b/src/packages/web-worker/pvm.ts
@@ -32,8 +32,8 @@ export const initPvm = (pvm: InternalPvmInstance, program: Uint8Array, initialSt
   }
 
   const pageSize = 2 ** 12;
-  const maxAddressFromPageMap = Math.max(0, ...pageMap.map((page) => page.address));
-  const hasMemoryLayout = maxAddressFromPageMap > 0;
+  const maxAddressFromPageMap = Math.max(...pageMap.map((page) => page.address));
+  const hasMemoryLayout = maxAddressFromPageMap >= 0;
   const heapStartIndex = tryAsSbrkIndex(hasMemoryLayout ? maxAddressFromPageMap + pageSize : 0);
   const heapEndIndex = tryAsSbrkIndex(2 ** 32 - 2 * 2 ** 16 - 2 ** 24);
 


### PR DESCRIPTION
I fixed the problem with memory initialization when there is only one page at the beginning (`0` - `2 ** 12`).

it closes https://github.com/FluffyLabs/pvm-debugger/issues/284